### PR TITLE
Fix GH pages deploy trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,12 @@
-name: Deploy to GitHub Pages
+name: Deploy teia-docs site to GitHub Pages
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
+    paths: # deploy only if Docusaurus site updated
+      - 'teia-docs/**'
+      - '.github/workflows/deploy.yml'
+    workflow_dispatch: # enables manual runs if needed
 
 jobs:
   deploy:


### PR DESCRIPTION
This change will update the workflow so it only deploys to GH pages when changes are made to the Docusaurus site.